### PR TITLE
Avoid issues when VMX_PATH contains spaces.

### DIFF
--- a/vmrun.wrapper
+++ b/vmrun.wrapper
@@ -73,7 +73,7 @@ function Stop()
 		exit 0
 	fi
 	
-	TOOL_STATUS=$(vmrun checkToolsState ${VMX_PATH})
+	TOOL_STATUS=$(vmrun checkToolsState "${VMX_PATH}")
 	
 	if [[ ${TOOL_STATUS} == "installed" ]]; then
 		Log "VMware tools are: ${TOOL_STATUS}. Attempting a soft shutdown."
@@ -115,7 +115,7 @@ while [[ true ]]; do
 
 	# Uncomment this line if you want to see the run loop.
 	#Log "Checking on the status of VM with PID ${ACTIVE_PID}"
-	ps ${ACTIVE_PID} |sed 1d |grep -o ${VMX_PATH} > /dev/null
+	ps ${ACTIVE_PID} |sed 1d |grep -o "${VMX_PATH}" > /dev/null
 	
 	if [[ ${?} != 0 ]]; then
 		Log "VM at ${VMX_PATH} with PID ${ACTIVE_PID} appears to have died. Exiting..."


### PR DESCRIPTION
PID-Check and Stop() should process the complete PATH to .vmx-file
